### PR TITLE
Syzygy Endgame Tablebase Support +10 Elo

### DIFF
--- a/Pedantic.Chess/Enums.cs
+++ b/Pedantic.Chess/Enums.cs
@@ -35,6 +35,22 @@ namespace Pedantic.Chess
         King
     }
 
+    public sealed class PieceComparer : IComparer<Piece>
+    {
+        public int Compare(Piece p1, Piece p2)
+        {
+            return (int)p1 - (int)p2;
+        }
+    }
+
+    public sealed class ReversePieceComparer : IComparer<Piece>
+    {
+        public int Compare(Piece p1, Piece p2)
+        {
+            return (int)p2 - (int)p1;
+        }
+    }
+
     [Flags]
     public enum CastlingRights : byte
     {
@@ -115,5 +131,13 @@ namespace Pedantic.Chess
         {
             return Evaluation.CanonicalPieceValues(piece);
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static char ToChar(this Piece piece)
+        {
+            return piece == Piece.None ? '-' : pieceChar[(int)piece];
+        }
+
+        private static readonly char[] pieceChar = { 'P', 'N', 'B', 'R', 'Q', 'K' };
     }
 }

--- a/Pedantic.Chess/Evaluation.cs
+++ b/Pedantic.Chess/Evaluation.cs
@@ -501,6 +501,23 @@ namespace Pedantic.Chess
             return w;
         }
 
+        public static ChessWeights LoadWeights(Guid? id)
+        {
+            var rep = new ChessDb();
+            ChessWeights? w = id == null
+                ? rep.Weights.FirstOrDefault(cw => cw.IsActive && cw.IsImmortal)
+                : rep.Weights.FirstOrDefault(cw => cw.Id == id);
+
+            if (w == null)
+            {
+                w = ChessWeights.CreateParagon();
+                rep.Weights.Insert(w);
+                rep.Save();
+            }
+            wt = new EvalWeights(w);
+            return w;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static short CanonicalPieceValues(Piece piece)
         {

--- a/Pedantic.Chess/Pedantic.Chess.csproj
+++ b/Pedantic.Chess/Pedantic.Chess.csproj
@@ -12,20 +12,24 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugType>full</DebugType>
+    <DefineConstants>$(DefineConstants);USE_TB</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <DebugType>full</DebugType>
+    <DefineConstants>$(DefineConstants);USE_TB</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <Optimize>True</Optimize>
     <DebugType>full</DebugType>
+    <DefineConstants>$(DefineConstants);USE_TB</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Optimize>True</Optimize>
     <DebugType>full</DebugType>
+    <DefineConstants>$(DefineConstants);USE_TB</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Pedantic.Chess/PieceLineup.cs
+++ b/Pedantic.Chess/PieceLineup.cs
@@ -1,13 +1,64 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Text;
 
 namespace Pedantic.Chess
 {
     public class PieceLineup
     {
+        public PieceLineup()
+        { }
 
+        public PieceLineup(Board board) : this()
+        { 
+            for (Color color = Color.White; color <= Color.Black; color++)
+            {
+                for (Piece piece = Piece.King; piece >= Piece.Pawn; --piece)
+                {
+                    pieceStrings[(int)color].AddPiece(piece);
+                }
+            }
+        }
+
+        public bool AddPiece(Color color, Piece piece)
+        {
+            return pieceStrings[(int)color].AddPiece(piece);
+        }
+
+        public bool RemovePiece(Color color, Piece piece)
+        {
+            return pieceStrings[(int)color].RemovePiece(piece);
+        }
+
+        public void Clear()
+        {
+            pieceStrings[0].Clear();
+            pieceStrings[1].Clear();
+        }
+
+        public PieceString this[Color color] => pieceStrings[(int)color];
+
+        public bool IsMatch(PieceString whitePcStr, PieceString blackPcStr)
+        {
+            return pieceStrings[0] == whitePcStr && pieceStrings[1] == blackPcStr;
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new();
+            if (pieceStrings[0].GetLength() > pieceStrings[1].GetLength())
+            {
+                sb.Append(pieceStrings[0]);
+                sb.Append('v');
+                sb.Append(pieceStrings[1]);
+            }
+            else
+            {
+                sb.Append(pieceStrings[1]);
+                sb.Append('v');
+                sb.Append(pieceStrings[0]);
+            }
+            return sb.ToString();
+        }
+
+        private PieceString[] pieceStrings = { new PieceString(), new PieceString() };
     }
 }

--- a/Pedantic.Chess/PieceString.cs
+++ b/Pedantic.Chess/PieceString.cs
@@ -1,0 +1,153 @@
+﻿using System.Text;
+
+namespace Pedantic.Chess
+{
+    public sealed class PieceString
+    {
+        public const int MAX_PIECE_STRING_LENGTH = 16;
+
+        public PieceString()
+        {
+            Array.Fill(pieces, Piece.None);
+        }
+
+        public PieceString(PieceString other)
+        {
+            Array.Copy(other.pieces, pieces, MAX_PIECE_STRING_LENGTH);
+        }
+
+        public PieceString(string str)
+            : this()
+        {
+            for (int n = 0; n < Math.Min(str.Length, MAX_PIECE_STRING_LENGTH); ++n)
+            {
+                Piece p = Conversion.ParsePiece(str[n]);
+                if (p != Piece.None)
+                {
+                    pieces[n] = p;
+                }
+                else
+                {
+                    break;
+                }
+            }
+            Array.Sort(pieces, 0, MAX_PIECE_STRING_LENGTH, pieceComparer);
+        }
+
+        public void Clear()
+        {
+            Array.Fill(pieces, Piece.None);
+        }
+
+        public bool AddPiece(Piece piece)
+        {
+            int n;
+            for (n = 0; n < MAX_PIECE_STRING_LENGTH; ++n)
+            {
+                if (piece > pieces[n])
+                {
+                    break;
+                }
+            }
+
+            if (n < MAX_PIECE_STRING_LENGTH)
+            {
+                for (int m = MAX_PIECE_STRING_LENGTH - 1; m > n; --m)
+                {
+                    pieces[m] = pieces[m - 1];
+                }
+                pieces[n] = piece;
+                return true;
+            }
+            return false;
+        }
+
+        public bool RemovePiece(Piece piece)
+        {
+            int index = Array.IndexOf(pieces, piece);
+            if (index >= 0)
+            {
+                for (int n = index; n < MAX_PIECE_STRING_LENGTH - 1; ++n)
+                {
+                    pieces[n] = pieces[n + 1];
+                }
+                pieces[MAX_PIECE_STRING_LENGTH - 1] = Piece.None;
+                return true;
+            }
+            return false;
+        }
+
+        public Piece this[int index] => pieces[index];
+
+        public bool Equals(PieceString? other)
+        {
+            return other != null && this == other;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return Equals(obj as PieceString);
+        }
+
+        public override int GetHashCode()
+        {
+            HashCode hash = new HashCode();
+            for (int n = 0; n < MAX_PIECE_STRING_LENGTH; ++n)
+            {
+                hash.Add(pieces[n]);
+            }
+            return hash.ToHashCode();
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            foreach (Piece p in pieces)
+            {
+                sb.Append(p.ToChar());
+            }
+            return sb.ToString();
+        }
+
+        public int GetLength()
+        {
+            int length = 0;
+            while (length < MAX_PIECE_STRING_LENGTH && pieces[length] != Piece.None)
+            {
+                length++;
+            }
+            return length;
+        }
+
+
+        public static bool operator == (PieceString? ps1, PieceString? ps2)
+        {
+            if (ps1 == null || ps2 == null)
+            {
+                return ps1 == null && ps2 == null;
+            }
+
+            for (int n = 0; n < MAX_PIECE_STRING_LENGTH; ++n)
+            {
+                if (ps1.pieces[n] != ps2.pieces[n])
+                {
+                    return false;
+                }
+                if (ps1.pieces[n] == Piece.None)
+                {
+                    break;
+                }
+            }
+            return true;
+        }
+
+        public static bool operator != (PieceString? ps1, PieceString? ps2)
+        {
+            return !(ps1 == ps2);
+        }
+
+        private Piece[] pieces = new Piece[MAX_PIECE_STRING_LENGTH];
+
+        private static readonly ReversePieceComparer pieceComparer = new ReversePieceComparer();
+    }
+}

--- a/Pedantic.Chess/Uci.cs
+++ b/Pedantic.Chess/Uci.cs
@@ -13,6 +13,7 @@
 //     A class that encapsulates UCI responses from the engine.
 // </summary>
 // ***********************************************************************
+using Pedantic.Tablebase;
 using Pedantic.Utilities;
 using System.Text;
 
@@ -54,11 +55,17 @@ namespace Pedantic.Chess
             }
         }
 
-        public static void Info(int depth, int seldepth, int score, long nodes, long timeMs, ulong[] pv, int hashfull)
+        public static void Info(int depth, int seldepth, int score, long nodes, long timeMs, ulong[] pv, int hashfull, long tbHits)
         {
             StringBuilder sb = new();
             int nps = (int)(nodes * 1000 / Math.Max(1, timeMs));
-            sb.Append(@$"info depth {depth} seldepth {seldepth} score cp {score} nodes {nodes} hashfull {hashfull} nps {nps} time {timeMs} pv");
+            sb.Append(@$"info depth {depth} seldepth {seldepth} score cp {score} nodes {nodes} hashfull {hashfull} nps {nps} time {timeMs} ");
+            if (tbHits > 0)
+            {
+                sb.Append(@$"tbhits {tbHits} ");
+            }
+
+            sb.Append("pv ");
             for (int n = 0; n < pv.Length; n++)
             {
                 sb.Append($@" {Move.ToString(pv[n])}");
@@ -73,11 +80,16 @@ namespace Pedantic.Chess
             Util.WriteLine(output);
         }
 
-        public static void InfoMate(int depth, int seldepth, int mateIn, long nodes, long timeMs, ulong[] pv, int hashfull)
+        public static void InfoMate(int depth, int seldepth, int mateIn, long nodes, long timeMs, ulong[] pv, int hashfull, long tbHits)
         {
             StringBuilder sb = new();
             int nps = (int)(nodes * 1000 / Math.Max(1, timeMs));
-            sb.Append(@$"info depth {depth} seldepth {seldepth} score mate {mateIn} nodes {nodes} hashfull {hashfull} nps {nps} time {timeMs} pv");
+            sb.Append(@$"info depth {depth} seldepth {seldepth} score mate {mateIn} nodes {nodes} hashfull {hashfull} nps {nps} time {timeMs} ");
+            if (tbHits > 0)
+            {
+                sb.Append($@"tbhits {tbHits} ");
+            }
+            sb.Append("pv ");
             for (int n = 0; n < pv.Length; n++)
             {
                 sb.Append($@" {Move.ToString(pv[n])}");

--- a/Pedantic.Chess/UciOptions.cs
+++ b/Pedantic.Chess/UciOptions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pedantic.Chess
+{
+    public static class UciOptions
+    {
+        public const bool DEFAULT_COLLECT_STATISTICS = false;
+        public const int DEFAULT_HASH = 64;
+        public const bool DEFAULT_OWN_BOOK = true;
+        public const bool DEFAULT_PONDER = false;
+        public const bool DEFAULT_RANDOM_SEARCH = false;
+        public const string DEFAULT_SYZYGY_PATH = "";
+        public const bool DEFAULT_SYZYGY_PROBE_ROOT = true;
+        public const int DEFAULT_SYZYGY_PROBE_DEPTH = 2;
+
+        static UciOptions()
+        {
+            CollectStatistics = DEFAULT_COLLECT_STATISTICS;
+            EvaluationID = null;
+            Hash = DEFAULT_HASH;
+            OwnBook = DEFAULT_OWN_BOOK;
+            Ponder = DEFAULT_PONDER;
+            RandomSearch = DEFAULT_RANDOM_SEARCH;
+            SyzygyPath = DEFAULT_SYZYGY_PATH;
+            SyzygyProbeRoot = DEFAULT_SYZYGY_PROBE_ROOT;
+            SyzygyProbeDepth = DEFAULT_SYZYGY_PROBE_DEPTH;
+        }
+
+        public static bool CollectStatistics { get; set; }
+        public static Guid? EvaluationID { get; set; }
+        public static int Hash { get; set;}
+        public static bool OwnBook { get; set; }
+        public static bool Ponder { get; set; }
+        public static bool RandomSearch { get; set; }
+        public static string SyzygyPath { get; set; }
+        public static bool SyzygyProbeRoot { get; set; }
+        public static int SyzygyProbeDepth { get; set; }
+    }
+}

--- a/Pedantic.Tablebase/Pedantic.Tablebase.h
+++ b/Pedantic.Tablebase/Pedantic.Tablebase.h
@@ -7,12 +7,12 @@ namespace Pedantic
 {
     namespace Tablebase
     {
-        public enum class TbGameResult : char
+        public enum class TbGameResult : System::SByte
         {
             Loss = 0, BlessedLoss, Draw, CursedWin, Win
         };
 
-        public enum class TbPromotes : char
+        public enum class TbPromotes : System::SByte
         {
             None = 0, Queen, Rook, Bishop, Knight
         };

--- a/Pedantic.Tablebase/Pedantic.Tablebase.vcxproj
+++ b/Pedantic.Tablebase/Pedantic.Tablebase.vcxproj
@@ -71,7 +71,10 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ManagedAssembly>true</ManagedAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <CopyLocalDeploymentContent>true</CopyLocalDeploymentContent>
+    <CopyCppRuntimeToOutputDir>true</CopyCppRuntimeToOutputDir>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
@@ -80,9 +83,14 @@
       <PreprocessorDefinitions>TB_NO_THREADS;TB_NO_HELPER_API;_CRT_SECURE_NO_WARNINGS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAs>CompileAsCpp</CompileAs>
       <DisableSpecificWarnings>4793;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
       <AdditionalDependencies />
+      <CLRImageType>ForceIJWImage</CLRImageType>
+      <CLRUnmanagedCodeCheck>true</CLRUnmanagedCodeCheck>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -103,6 +111,7 @@
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>TB_NO_THREADS;TB_NO_HELPER_API;_CRT_SECURE_NO_WARNINGS;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAs>CompileAsCpp</CompileAs>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
       <AdditionalDependencies />

--- a/Pedantic.Tablebase/pch.h
+++ b/Pedantic.Tablebase/pch.h
@@ -26,6 +26,5 @@
 #else
 #include <stdbool.h>
 #endif
-#include "tbprobe.h"
 
 #endif //PCH_H

--- a/Pedantic.Tablebase/tbprobe.c
+++ b/Pedantic.Tablebase/tbprobe.c
@@ -23,6 +23,9 @@ SOFTWARE.
 */
 
 #include "pch.h"
+#pragma unmanaged
+
+#include "tbprobe.h"
 
 #define TB_PIECES 7
 #define TB_HASHBITS  (TB_PIECES < 7 ?  11 : 12)
@@ -182,8 +185,6 @@ static unsigned lsb(uint64_t b) {
 #define min(a,b) a < b ? a : b
 
 #include "stdendian.h"
-
-#pragma unmanaged
 
 #if _BYTE_ORDER == _BIG_ENDIAN
 

--- a/Pedantic.UnitTests/Pedantic.UnitTests.csproj
+++ b/Pedantic.UnitTests/Pedantic.UnitTests.csproj
@@ -15,20 +15,24 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugType>full</DebugType>
+    <DefineConstants>$(DefineConstants);USE_TB</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <DebugType>full</DebugType>
+    <DefineConstants>$(DefineConstants);USE_TB</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>full</DebugType>
     <Optimize>True</Optimize>
+    <DefineConstants>$(DefineConstants);USE_TB</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <DebugType>full</DebugType>
     <Optimize>True</Optimize>
+    <DefineConstants>$(DefineConstants);USE_TB</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Pedantic.UnitTests/ProgramTests.cs
+++ b/Pedantic.UnitTests/ProgramTests.cs
@@ -36,7 +36,7 @@ namespace Pedantic.UnitTests
         [TestMethod]
         public void GoBookMoveTest()
         {
-            Engine.UseOwnBook = true;
+            UciOptions.OwnBook = true;
             Program.ParseCommand(@"position startpos moves e2e4");
             Console.WriteLine(Engine.Board.ToString());
             Program.ParseCommand(@"go wtime 300000 btime 300000 winc 0 binc 0");
@@ -46,7 +46,7 @@ namespace Pedantic.UnitTests
         [TestMethod]
         public void GoBookMove2Test()
         {
-            Engine.UseOwnBook = true;
+            UciOptions.OwnBook = true;
             Program.ParseCommand("position startpos moves e2e4 e7e5 g1f3");
             Console.WriteLine(Engine.Board.ToString());
             Program.ParseCommand("go wtime 293797 btime 300000 winc 0 binc 0 movestogo 39");
@@ -56,7 +56,7 @@ namespace Pedantic.UnitTests
         [TestMethod]
         public void GoBookMove3Test()
         {
-            Engine.UseOwnBook = true;
+            UciOptions.OwnBook = true;
             Program.ParseCommand(
                 "position fen rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1 moves e7e5 g1f3");
             Console.WriteLine(Engine.Board.ToString());
@@ -67,7 +67,7 @@ namespace Pedantic.UnitTests
         [TestMethod]
         public void GoBookMove4Test()
         {
-            Engine.UseOwnBook = true;
+            UciOptions.OwnBook = true;
             Program.ParseCommand(
                 "position startpos moves e2e4 c7c5 g1f3 b8c6 d2d4 c5d4 f3d4 g8f6 b1c3 e7e5 d4b5 d7d6 c1g5 a7a6 b5a3 b7b5 g5f6 g7f6 c3d5 f6f5 f1d3 c8e6 e1g1 f8g7 d1h5 f5f4 c2c4 b5c4 d3c4");
             Console.WriteLine(Engine.Board.ToString());
@@ -99,7 +99,8 @@ namespace Pedantic.UnitTests
         {
             try
             {
-                Engine.ResizeHashTable(128);
+                UciOptions.Hash = 128;
+                Engine.ResizeHashTable();
                 Engine.LoadBookEntries();
                 Program.ParseCommand(
                     "position startpos moves e2e4 c7c5 g1f3 d7d6 d2d4 c5d4 f3d4 g8f6 b1c3 b8c6 f1c4 e7e6 c1e3 f8e7 c4b3 e8g8 f2f4 c8d7 d4b5 d8b8 a2a4 a7a6 b5a3 c6a5 e3b6 a5b3 c2b3 d7c6 e1g1 f6e4 a3c4 e7d8 d1d4 f7f5 c3e4 f5e4 b6d8 f8d8 c4b6 b8a7 a4a5 a8c8 f4f5 e6e5 d4d1 c8c7 d1g4 c7f7 f5f6 a7b8 a1e1 d8e8 f1f2 d6d5 f6g7 f7g7 g4h4 d5d4 e1e4 c6e4 h4e4 b8d6 b6c4 d6c6 e4c6 b7c6 f2f6 g7g6 f6f5 e5e4 f5e5 e8e5 c4e5 g6e6 e5c4 e4e3 g1f1 e3e2 f1e1 h7h5 h2h3 d4d3");
@@ -121,7 +122,7 @@ namespace Pedantic.UnitTests
         [TestMethod]
         public void BadBookMoveTest()
         {
-            Engine.UseOwnBook = true;
+            UciOptions.OwnBook = true;
             Engine.LoadBookEntries();
             Program.ParseCommand(
                 "position startpos moves d2d4 g8f6 g1f3 e7e6 c2c4 b7b6 g2g3 c8b7 f1g2 f8e7 b1c3 f6e4 c1d2 e7f6 e1g1");
@@ -137,7 +138,7 @@ namespace Pedantic.UnitTests
         public void CheckMateInOneTest(string fen)
         {
             //Engine.Infinite = true;
-            Engine.UseOwnBook = true;
+            UciOptions.OwnBook = true;
             Program.ParseCommand(@$"position fen {fen}");
             Program.ParseCommand("go wtime 300000 btime 300000 winc 0 binc 0");
             Engine.Wait();
@@ -149,7 +150,7 @@ namespace Pedantic.UnitTests
         public void CheckMateInTwoTest(string fen)
         {
             //Engine.Infinite = true;
-            Engine.UseOwnBook = true;
+            UciOptions.OwnBook = true;
             Program.ParseCommand(@$"position fen {fen}");
             Program.ParseCommand("go depth 2");
             Engine.Wait();
@@ -162,7 +163,7 @@ namespace Pedantic.UnitTests
         public void CheckMateInThreeTest(string fen)
         {
             //Engine.Infinite = true;
-            Engine.UseOwnBook = true;
+            UciOptions.OwnBook = true;
             Program.ParseCommand(@$"position fen {fen}");
             Program.ParseCommand("go depth 13");
             Engine.Wait();
@@ -175,7 +176,7 @@ namespace Pedantic.UnitTests
         public void CheckMateInFourTest(string fen)
         {
             //Engine.Infinite = true;
-            Engine.UseOwnBook = true;
+            UciOptions.OwnBook = true;
             Program.ParseCommand(@$"position fen {fen}");
             Program.ParseCommand("go depth 24");
             Engine.Wait();

--- a/Pedantic.Utilities/Mem.cs
+++ b/Pedantic.Utilities/Mem.cs
@@ -48,5 +48,14 @@ namespace Pedantic.Utilities
                 Array.Clear(array[i]);
             }
         }
+
+        public static void Fill<T>(T[][] array, T fillValue)
+        {
+            for (int i = 0; i < array.Length; ++i)
+            {
+                Array.Fill(array[i], fillValue);
+            }
+        }
+
     }
 }

--- a/Pedantic.Utilities/Pedantic.Utilities.csproj
+++ b/Pedantic.Utilities/Pedantic.Utilities.csproj
@@ -6,7 +6,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Platforms>AnyCPU;x64</Platforms>
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>

--- a/Pedantic/Pedantic.csproj
+++ b/Pedantic/Pedantic.csproj
@@ -3,7 +3,11 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0-windows8.0</TargetFramework>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SupportedOSPlatformVersion>8.0</SupportedOSPlatformVersion>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>    
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
@@ -16,20 +20,24 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugType>full</DebugType>
+    <DefineConstants>$(DefineConstants);USE_TB</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <DebugType>full</DebugType>
+    <DefineConstants>$(DefineConstants);USE_TB</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <Optimize>True</Optimize>
     <DebugType>full</DebugType>
+    <DefineConstants>$(DefineConstants);USE_TB</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Optimize>True</Optimize>
     <DebugType>full</DebugType>
+    <DefineConstants>$(DefineConstants);USE_TB</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -40,7 +48,9 @@
     <ProjectReference Include="..\Pedantic.Chess\Pedantic.Chess.csproj" />
     <ProjectReference Include="..\Pedantic.Collections\Pedantic.Collections.csproj" />
     <ProjectReference Include="..\Pedantic.Genetics\Pedantic.Genetics.csproj" />
-    <ProjectReference Include="..\Pedantic.Tablebase\Pedantic.Tablebase.vcxproj" />
+    <ProjectReference Include="..\Pedantic.Tablebase\Pedantic.Tablebase.vcxproj">
+        <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+    </ProjectReference>
     <ProjectReference Include="..\Pedantic.Utilities\Pedantic.Utilities.csproj" />
   </ItemGroup>
 

--- a/Pedantic/Properties/PublishProfiles/Windows X64.pubxml
+++ b/Pedantic/Properties/PublishProfiles/Windows X64.pubxml
@@ -12,7 +12,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <TargetFramework>net7.0-windows8.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
-    <PublishSingleFile>false</PublishSingleFile>
     <PublishReadyToRun>false</PublishReadyToRun>
     <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>


### PR DESCRIPTION
Score of Pedantic 0.4A (2) vs Pedantic 0.4B (0): 1606 - 1449 - 2182  [0.515] 5237
...      Pedantic 0.4A (2) playing White: 907 - 639 - 1072  [0.551] 2618
...      Pedantic 0.4A (2) playing Black: 699 - 810 - 1110  [0.479] 2619
...      White vs Black: 1717 - 1338 - 2182  [0.536] 5237
Elo difference: 10.4 +/- 7.2, LOS: 99.8 %, DrawRatio: 41.7 %
SPRT: llr 2.95 (100.1%), lbound -2.94, ubound 2.94 - H1 was accepted