### PR TITLE
Optimized aspiration windows (25, 100) => (33, 100, 200, 300),  +14 Elo

### DIFF
--- a/Pedantic.Chess/Constants.cs
+++ b/Pedantic.Chess/Constants.cs
@@ -39,15 +39,7 @@ namespace Pedantic.Chess
         public const short BAD_CAPTURE = 6000;
         public const short HISTORY_SCORE = 5000;
         public const short INFINITE_WINDOW = short.MaxValue;
-        public const ulong LINEUP_K = 0ul;
-        public const ulong LINEUP_KQ = 0x0005ul;
-        public const ulong LINEUP_KR = 0x0004ul;
-        public const ulong LINEUP_KB = 0x0003ul;
-        public const ulong LINEUP_KN = 0x0002ul;
-        public const ulong LINEUP_KP = 0x0001ul;
-        public const ulong LINEUP_KNN = 0x0012ul;
-        public const ulong LINEUP_KBN = 0x001Aul;
-        public const ulong LINEUP_KBB = 0x001Bul;
+        public const int WINDOW_MIN_DEPTH = 6;
         public const int LAZY_EVAL_MARGIN = 500;
         public const int INVALID_PROBE = int.MinValue;
 
@@ -57,5 +49,6 @@ namespace Pedantic.Chess
         public const string FEN_EMPTY = @"8/8/8/8/8/8/8/8 w - - 0 0";
         public const string FEN_START_POS = @"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
         public const string APP_NAME = "Pedantic";
+        public const string APP_VERSION = "0.4.0";
     }
 }

--- a/Pedantic.Chess/Uci.cs
+++ b/Pedantic.Chess/Uci.cs
@@ -55,11 +55,21 @@ namespace Pedantic.Chess
             }
         }
 
-        public static void Info(int depth, int seldepth, int score, long nodes, long timeMs, ulong[] pv, int hashfull, long tbHits)
+        public static void Info(int depth, int seldepth, int score, long nodes, long timeMs, ulong[] pv, 
+            int hashfull, long tbHits, TtFlag flag = TtFlag.Exact)
         {
             StringBuilder sb = new();
             int nps = (int)(nodes * 1000 / Math.Max(1, timeMs));
-            sb.Append(@$"info depth {depth} seldepth {seldepth} score cp {score} nodes {nodes} hashfull {hashfull} nps {nps} time {timeMs} ");
+            sb.Append(@$"info depth {depth} seldepth {seldepth} score cp {score}");
+            if (flag == TtFlag.UpperBound)
+            {
+                sb.Append(" upperbound");
+            }
+            else if (flag == TtFlag.LowerBound)
+            {
+                sb.Append(" lowerbound");
+            }
+            sb.Append(@$" nodes {nodes} hashfull {hashfull} nps {nps} time {timeMs} ");
             if (tbHits > 0)
             {
                 sb.Append(@$"tbhits {tbHits} ");

--- a/Pedantic/Program.cs
+++ b/Pedantic/Program.cs
@@ -28,8 +28,8 @@ namespace Pedantic
 {
     public static class Program
     {
-        public const string APP_NAME = "Pedantic";
-        public const string APP_VERSION = "0.4.0";
+        public const string APP_NAME = Constants.APP_NAME;
+        public const string APP_VERSION = Constants.APP_VERSION;
         public const string APP_NAME_VER = APP_NAME + " " + APP_VERSION;
         public const string AUTHOR = "JoAnn D. Peeler";
         public const string PROGRAM_URL = "https://github.com/JoAnnP38/Pedantic";


### PR DESCRIPTION
Score of Pedantic 0.4 (33) vs Pedantic 0.4 (25): 922 - 812 - 973  [0.520] 2707
...      Pedantic 0.4 (33) playing White: 502 - 364 - 487  [0.551] 1353
...      Pedantic 0.4 (33) playing Black: 420 - 448 - 486  [0.490] 1354
...      White vs Black: 950 - 784 - 973  [0.531] 2707
Elo difference: 14.1 +/- 10.5, LOS: 99.6 %, DrawRatio: 35.9 %
SPRT: llr 2.21 (100.6%), lbound -2.2, ubound 2.2 - H1 was accepted