### PR TITLE
Redesign TT aging so that replacement prefers older records with grea…

### DIFF
--- a/Pedantic.Chess/BasicSearch.cs
+++ b/Pedantic.Chess/BasicSearch.cs
@@ -182,22 +182,8 @@ namespace Pedantic.Chess
                 location = "12";
                 Uci.BestMove(bestMove, CanPonder ? ponderMove : null);
                 location = "13";
-                
-                if (board.TotalMaterialNoKings < Evaluation.EndGamePhaseMaterial /*+ Piece.Rook.Value()*/)
-                {
-                    // don't clear hash table unless we have enough time (a 256mb cache
-                    // takes about 78ms to clear on a AMD Ryzen 9 6800HX cpu.)
-                    if ((time.TimeLimit >> 2) >= 100)
-                    {
-                        Uci.Debug("Clearing hash table");
-                        TtTran.Clear();
-                    }
-                    else
-                    {
-                        Uci.Debug("Incrementing hash table version.");
-                        TtTran.IncrementVersion();
-                    }
-                }
+                Uci.Debug("Incrementing hash table version.");
+                TtTran.IncrementVersion();
             }
             catch (Exception ex)
             {
@@ -485,7 +471,7 @@ namespace Pedantic.Chess
                 bool badCapture = Move.IsCapture(move) && Move.GetScore(move) == Constants.BAD_CAPTURE /* Move.IsBadCapture(move) */;
                 bool interesting = inCheck || checkingMove || (!isQuiet && !badCapture) || isKiller || expandedNodes == 1;
 
-                if (canPrune && !interesting && expandedNodes > LMP[depth]/* && Move.GetScore(move) < LMP_MAX_HISTORY*/)
+                if (canPrune && !interesting && expandedNodes > LMP[depth])
                 {
                     board.UnmakeMoveNs();
                     continue;


### PR DESCRIPTION
…ter depth. Fix need to clear TT every search. +6 Elo

Score of Pedantic 0.4 (New TT) vs Pedantic 0.4 (Old TT): 2222 - 2097 - 2628  [0.509] 6947
...      Pedantic 0.4 (New TT) playing White: 1229 - 960 - 1285  [0.539] 3474
...      Pedantic 0.4 (New TT) playing Black: 993 - 1137 - 1343  [0.479] 3473
...      White vs Black: 2366 - 1953 - 2628  [0.530] 6947
Elo difference: 6.3 +/- 6.4, LOS: 97.1 %, DrawRatio: 37.8 %
SPRT: llr 2.2 (100.1%), lbound -2.2, ubound 2.2 - H1 was accepted