### PR TITLE
SEARCH: Counter move heuristic +15 Elo.

### DIFF
--- a/Pedantic.Chess/BasicSearch.cs
+++ b/Pedantic.Chess/BasicSearch.cs
@@ -215,7 +215,7 @@ namespace Pedantic.Chess
 
             int expandedNodes = 0;
             bool raisedAlpha = false;
-            history.SideToMove = board.SideToMove;
+            history.SetContext(board);
             MoveList moveList = GetMoveList();
             ulong bestMove = 0ul;
             IEnumerable<ulong> moves = board.Moves(0, killerMoves, history, moveList);
@@ -441,7 +441,7 @@ namespace Pedantic.Chess
             }
 
             int expandedNodes = 0;
-            history.SideToMove = board.SideToMove;
+            history.SetContext(board);
             MoveList moveList = GetMoveList();
             bestMove = 0ul;
             IEnumerable<ulong> moves = board.Moves(ply, killerMoves, history, moveList);

--- a/Pedantic.Chess/Board.cs
+++ b/Pedantic.Chess/Board.cs
@@ -958,23 +958,25 @@ namespace Pedantic.Chess
                 }
             }
 
-            KillerMoves.KillerMove km = killerMoves.GetKillers(ply);
-            from = Move.GetFrom(km.Killer0);
-            int to = Move.GetTo(km.Killer0);
-            Square square = board[from];
             moveList.Clear();
-            if (IsValidMove(square, from, to, out ulong validMove) && Move.Compare(validMove, bestMove) != 0)
+            GenerateQuietMoves(moveList, history);
+            moveList.Remove(bestMove);
+
+            KillerMoves.KillerMove km = killerMoves.GetKillers(ply);
+            
+            if (moveList.Remove(km.Killer0))
             {
-                yield return validMove;
+                yield return km.Killer0;
             }
 
-            from = Move.GetFrom(km.Killer1);
-            to = Move.GetTo(km.Killer1);
-            square = board[from];
-            moveList.Clear();
-            if (IsValidMove(square, from, to, out validMove) && Move.Compare(validMove, bestMove) != 0)
+            if (moveList.Remove(km.Killer1))
             {
-                yield return validMove;
+                yield return km.Killer1;
+            }
+
+            if (moveList.Remove(history.CounterMove))
+            {
+                yield return history.CounterMove;
             }
                 
             // now return the bad captures deferred from earlier
@@ -983,16 +985,9 @@ namespace Pedantic.Chess
                 yield return bc[n];
             }
 
-            moveList.Clear();
-            GenerateQuietMoves(moveList, history);
             for (int n = 0; n < moveList.Count; n++)
             {
-                moveList.Sort(n);
-                if (Move.Compare(moveList[n], bestMove) == 0 || killerMoves.Exists(ply, moveList[n]))
-                {
-                    continue;
-                }
-                yield return moveList[n];
+                yield return moveList.Sort(n);
             }
         }
 
@@ -1065,8 +1060,7 @@ namespace Pedantic.Chess
 
             for (int n = 0; n < moveList.Count; n++)
             {
-                moveList.Sort(n);
-                yield return moveList[n];
+                yield return moveList.Sort(n);
             }
         }
 

--- a/Pedantic.Chess/KillerMoves.cs
+++ b/Pedantic.Chess/KillerMoves.cs
@@ -69,7 +69,7 @@ namespace Pedantic.Chess
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool MovesEqual(ulong move1, ulong move2)
         {
-            return (move1 & 0x0fff) == (move2 & 0x0fff);
+            return Move.Compare(move1, move2) == 0;
         }
 
         private readonly KillerMove[] killers;

--- a/Pedantic.Chess/MoveList.cs
+++ b/Pedantic.Chess/MoveList.cs
@@ -16,6 +16,7 @@
 // ***********************************************************************
 using Pedantic.Collections;
 using Pedantic.Utilities;
+using System;
 
 namespace Pedantic.Chess
 {
@@ -60,6 +61,19 @@ namespace Pedantic.Chess
             }
         }
 
+        public new bool Remove(ulong move)
+        {
+            for (int n = 0; n < insertIndex; n++)
+            {
+                if (Move.Compare(array[n], move) == 0)
+                {
+                    array[n] = array[--insertIndex];
+                    return true;
+                }
+            }
+            return false;
+        }
+
         public ReadOnlySpan<ulong> ToSpan() => new(array, 0, Count);
 
         public void UpdateScores(ulong pv, KillerMoves killerMoves, int ply)
@@ -70,10 +84,9 @@ namespace Pedantic.Chess
             for (int n = 0; n < insertIndex && found < 3; ++n)
             {
                 ulong move = array[n];
-                ulong fromto = move & 0x0fff;
                 bool isCapture = Move.GetCapture(move) != Piece.None;
 
-                if (fromto == (pv & 0x0fff))
+                if (Move.Compare(move, pv) == 0)
                 {
                     array[n] = Move.SetScore(move, Constants.PV_SCORE);
                     found++;


### PR DESCRIPTION
Score of Pedantic 0.4 Chg vs Pedantic 0.4 Org: 1424 - 1245 - 1550  [0.521] 4219
...      Pedantic 0.4 Chg playing White: 787 - 538 - 785  [0.559] 2110
...      Pedantic 0.4 Chg playing Black: 637 - 707 - 765  [0.483] 2109
...      White vs Black: 1494 - 1175 - 1550  [0.538] 4219
Elo difference: 14.7 +/- 8.3, LOS: 100.0 %, DrawRatio: 36.7 %
SPRT: llr 2.2 (100.0%), lbound -2.2, ubound 2.2 - H1 was accepted