### PR TITLE
SEARCH: Refactor hist [from][to] => [piece][to] +8 Elo

### DIFF
--- a/Pedantic.Chess/BasicSearch.cs
+++ b/Pedantic.Chess/BasicSearch.cs
@@ -288,7 +288,7 @@ namespace Pedantic.Chess
                         if (isQuiet)
                         {
                             killerMoves.Add(move, 0);
-                            history.Update(move, HistoryBonus(depth));
+                            history.Update(board, move, HistoryBonus(depth));
                         }
 
                         break;
@@ -542,7 +542,7 @@ namespace Pedantic.Chess
                         if (isQuiet)
                         {
                             killerMoves.Add(move, ply);
-                            history.Update(move, HistoryBonus(depth));
+                            history.Update(board, move, HistoryBonus(depth));
                         }
 
                         break;

--- a/Pedantic.Chess/Board.cs
+++ b/Pedantic.Chess/Board.cs
@@ -1240,7 +1240,7 @@ namespace Pedantic.Chess
                     for (ulong bb3 = BitOps.AndNot(bb2, All); bb3 != 0; bb3 = BitOps.ResetLsb(bb3))
                     {
                         int to = BitOps.TzCount(bb3);
-                        list.Add(from, to, score: hist[from, to]);
+                        list.Add(from, to, score: hist[piece, to]);
                     }
                 }
             }
@@ -1258,7 +1258,7 @@ namespace Pedantic.Chess
             for (ulong bb3 = BitOps.AndNot(bb2, All); bb3 != 0; bb3 = BitOps.ResetLsb(bb3))
             {
                 int to = BitOps.TzCount(bb3);
-                list.Add(from, to, score: hist[from, to]);
+                list.Add(from, to, score: hist[piece, to]);
             }
         }
 
@@ -1296,7 +1296,8 @@ namespace Pedantic.Chess
                     for (ulong bb3 = BitOps.AndNot(bb2, All); bb3 != 0; bb3 = BitOps.ResetLsb(bb3))
                     {
                         int to = BitOps.TzCount(bb3);
-                        list.Add(from, to, score: history[from, to]);
+                        Util.Assert(Index.IsValid(to), $"'to' out of range: {to}");
+                        list.Add(from, to, score: history[piece, to]);
                     }
                 }
             }
@@ -1370,24 +1371,24 @@ namespace Pedantic.Chess
             {
                 if ((castling & CastlingRights.WhiteKingSide) != 0 && (WHITE_KS_CLEAR_MASK & All) == 0)
                 {
-                    list.Add(Index.E1, Index.G1, MoveType.Castle, score: hist[Index.E1, Index.G1]);
+                    list.Add(Index.E1, Index.G1, MoveType.Castle, score: hist[Piece.King, Index.G1]);
                 }
 
                 if ((castling & CastlingRights.WhiteQueenSide) != 0 && (WHITE_QS_CLEAR_MASK & All) == 0)
                 {
-                    list.Add(Index.E1, Index.C1, MoveType.Castle, score: hist[Index.E1, Index.C1]);
+                    list.Add(Index.E1, Index.C1, MoveType.Castle, score: hist[Piece.King, Index.C1]);
                 }
             }
             else
             {
                 if ((castling & CastlingRights.BlackKingSide) != 0 && (BLACK_KS_CLEAR_MASK & All) == 0)
                 {
-                    list.Add(Index.E8, Index.G8, MoveType.Castle, score: hist[Index.E8, Index.G8]);
+                    list.Add(Index.E8, Index.G8, MoveType.Castle, score: hist[Piece.King, Index.G8]);
                 }
 
                 if ((castling & CastlingRights.BlackQueenSide) != 0 && (BLACK_QS_CLEAR_MASK & All) == 0)
                 {
-                    list.Add(Index.E8, Index.C8, MoveType.Castle, score: hist[Index.E8, Index.C8]);
+                    list.Add(Index.E8, Index.C8, MoveType.Castle, score: hist[Piece.King, Index.C8]);
                 }
             }
         }
@@ -1412,14 +1413,14 @@ namespace Pedantic.Chess
             {
                 from = BitOps.TzCount(bb1);
                 to = PawnPlus[(int)sideToMove, from];
-                AddPawnMove(list, from, to, score: hist[from, to]);
+                AddPawnMove(list, from, to, score: hist[Piece.Pawn, to]);
             }
 
             for (; bb2 != 0; bb2 = BitOps.ResetLsb(bb2))
             {
                 from = BitOps.TzCount(bb2);
                 to = pawnDouble[(int)sideToMove, from];
-                list.Add(from, to, MoveType.DblPawnMove, score: hist[from, to]);
+                list.Add(from, to, MoveType.DblPawnMove, score: hist[Piece.Pawn, to]);
             }
         }
 
@@ -1460,14 +1461,14 @@ namespace Pedantic.Chess
             {
                 from = BitOps.TzCount(bb3);
                 to = PawnPlus[(int)sideToMove, from];
-                AddPawnMove(list, from, to, MoveType.PawnMove, score: hist[from, to]);
+                AddPawnMove(list, from, to, MoveType.PawnMove, score: hist[Piece.Pawn, to]);
             }
 
             for (; bb4 != 0; bb4 = BitOps.ResetLsb(bb4))
             {
                 from = BitOps.TzCount(bb4);
                 to = pawnDouble[(int)sideToMove, from];
-                list.Add(from, to, MoveType.DblPawnMove, score: hist[from, to]);
+                list.Add(from, to, MoveType.DblPawnMove, score: hist[Piece.Pawn, to]);
             }
         }
 
@@ -1512,7 +1513,7 @@ namespace Pedantic.Chess
                 to = PawnPlus[(int)sideToMove, from];
                 if (BitOps.GetBit(validSquares, to) != 0)
                 {
-                    AddPawnMove(list, from, to, score: hist[from, to]);
+                    AddPawnMove(list, from, to, score: hist[Piece.Pawn, to]);
                 }
             }
 
@@ -1522,7 +1523,7 @@ namespace Pedantic.Chess
                 to = pawnDouble[(int)sideToMove, from];
                 if (BitOps.GetBit(validSquares, to) != 0)
                 {
-                    list.Add(from, to, MoveType.DblPawnMove, score: hist[from, to]);
+                    list.Add(from, to, MoveType.DblPawnMove, score: hist[Piece.Pawn, to]);
                 }
             }
         }
@@ -1707,7 +1708,7 @@ namespace Pedantic.Chess
             for (ulong bb = kingMoves[kingIndex] & ~all; bb != 0; bb = BitOps.ResetLsb(bb))
             {
                 int to = BitOps.TzCount(bb);
-                moveList.Add(kingIndex, to, score: hist[kingIndex, to]);
+                moveList.Add(kingIndex, to, score: hist[Piece.King, to]);
             }
 
             if (checkCount > 1)
@@ -1747,7 +1748,7 @@ namespace Pedantic.Chess
                         int to = BitOps.TzCount(bb3);
                         if (BitOps.GetBit(attacksFrom, to) != 0)
                         {
-                            moveList.Add(from, to, score: hist[from, to]);
+                            moveList.Add(from, to, score: hist[piece, to]);
                         }
                     }
                 }
@@ -2003,7 +2004,7 @@ namespace Pedantic.Chess
 
         private class FakeHistory : IHistory
         {
-            public short this[int from, int to] => 0;
+            public short this[Piece piece, int to] => 0;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Pedantic.Chess/Engine.cs
+++ b/Pedantic.Chess/Engine.cs
@@ -16,6 +16,7 @@
 
 using Pedantic.Genetics;
 using Pedantic.Utilities;
+using System.Diagnostics;
 
 namespace Pedantic.Chess
 {
@@ -406,6 +407,7 @@ namespace Pedantic.Chess
                 CanPonder = UciOptions.Ponder,
                 CollectStats = UciOptions.CollectStatistics
             };
+            Debugger.Break();
             searchThread = new Thread(() => search.Search())
             {
                 Priority = ThreadPriority.Highest

--- a/Pedantic.Chess/Interfaces.cs
+++ b/Pedantic.Chess/Interfaces.cs
@@ -2,7 +2,7 @@
 {
     public interface IHistory
     {
-        public short this[int from, int to] { get; }
+        public short this[Piece piece, int to] { get; }
     }
 
     public interface IMoveScorer

--- a/Pedantic.Utilities/Util.cs
+++ b/Pedantic.Utilities/Util.cs
@@ -13,7 +13,7 @@
 //     Methods used to ensure correctness of the application in real-time.
 // </summary>
 // ***********************************************************************
-#undef DEBUG
+//#undef DEBUG
 using System.Diagnostics;
 
 namespace Pedantic.Utilities
@@ -78,6 +78,7 @@ namespace Pedantic.Utilities
             }
             else if (!condition)
             {
+                TraceError(message);
                 throw new AssertionException(message);
             }
         }

--- a/Pedantic/Properties/launchSettings.json
+++ b/Pedantic/Properties/launchSettings.json
@@ -4,7 +4,7 @@
       "commandName": "Project",
       "commandLineArgs": "learn --data \"e:/pgn files/training_data_ver4.0.csv\" --sample 12000000 --iter 20 --save",
       "workingDirectory": "e:\\repos\\Pedantic\\Pedantic\\bin\\Release\\net7.0\\publish",
-      "nativeDebugging": true
+      "nativeDebugging": false
     }
   }
 }


### PR DESCRIPTION
Score of Pedantic 0.4 Chg vs Pedantic 0.4 Org: 2948 - 2749 - 3405  [0.511] 9102
...      Pedantic 0.4 Chg playing White: 1579 - 1276 - 1695  [0.533] 4550
...      Pedantic 0.4 Chg playing Black: 1369 - 1473 - 1710  [0.489] 4552
...      White vs Black: 3052 - 2645 - 3405  [0.522] 9102
Elo difference: 7.6 +/- 5.6, LOS: 99.6 %, DrawRatio: 37.4 %
SPRT: llr 2.2 (100.3%), lbound -2.2, ubound 2.2 - H1 was accepted