### PR TITLE
Improve NMP +20 Elo

### DIFF
--- a/Pedantic.Chess/BasicSearch.cs
+++ b/Pedantic.Chess/BasicSearch.cs
@@ -33,8 +33,8 @@ namespace Pedantic.Chess
         internal const int STATIC_NULL_MOVE_MAX_DEPTH = 6;
         internal const int STATIC_NULL_MOVE_MARGIN = 75; 
         internal const int NMP_MIN_DEPTH = 3;
-        internal const int NMP_BASE_REDUCTION = 2;
-        internal const int NMP_INC_DIVISOR = 4; 
+        internal const int NMP_BASE_REDUCTION = 3;
+        internal const int NMP_INC_DIVISOR = 5; 
         internal const int RAZOR_MAX_DEPTH = 3;
         internal const int IID_MIN_DEPTH = 5;
         internal const int LMP_MAX_HISTORY = 32;
@@ -357,7 +357,7 @@ namespace Pedantic.Chess
                 return alpha;
             }
 
-            if (TtTran.TryGetScore(board.Hash, depth, ply, alpha, beta, out int score, out ulong bestMove))
+            if (TtTran.TryGetScore(board.Hash, depth, ply, alpha, beta, out bool avoidNmp, out int score, out ulong bestMove))
             { 
                 return score;
             }
@@ -394,7 +394,7 @@ namespace Pedantic.Chess
                 }
 
                 // null move pruning
-                if (canNull && depth >= NMP_MIN_DEPTH && eval >= beta && board.PieceCount(board.SideToMove) > 1)
+                if (!avoidNmp && canNull && depth >= NMP_MIN_DEPTH && eval >= beta && board.PieceCount(board.SideToMove) > 1)
                 {
                     int R = NMP[depth];
                     //int R = NmpReduction(depth);
@@ -619,7 +619,7 @@ namespace Pedantic.Chess
                 return Contempt;
             }
 
-            if (TtTran.TryGetScore(board.Hash, -qsPly, ply, alpha, beta, out int score, move: out ulong _))
+            if (TtTran.TryGetScore(board.Hash, -qsPly, ply, alpha, beta, out bool _, out int score, move: out ulong _))
             { 
                 return score;
             }
@@ -1054,9 +1054,9 @@ namespace Pedantic.Chess
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int NmpReduction(int depth)
+        public static int NmpReduction(int depth)
         {
-            return NMP_BASE_REDUCTION + Math.Max(depth - 3, 0) / NMP_INC_DIVISOR + 1;
+            return depth < 3 ? 0 : NMP_BASE_REDUCTION + Math.Max(depth - 3, 0) / NMP_INC_DIVISOR;
         }
 
         private readonly Board board;
@@ -1545,9 +1545,9 @@ namespace Pedantic.Chess
         internal static readonly sbyte[] NMP =
         {
             #region nmp data
-            0, 0, 0, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 8, 9, 9, 9, 9, 10, 
-            10, 10, 10, 11, 11, 11, 11, 12, 12, 12, 12, 13, 13, 13, 13, 14, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 
-            17, 17, 17, 17, 18
+            0, 0, 0, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 8, 8, 8, 8, 
+            8, 9, 9, 9, 9, 9, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 12, 12, 12, 12, 12, 13, 13, 13, 13, 13, 
+            14, 14, 14, 14, 14, 15
             #endregion nmp data
         };
 

--- a/Pedantic.Chess/TtTran.cs
+++ b/Pedantic.Chess/TtTran.cs
@@ -191,11 +191,12 @@ namespace Pedantic.Chess
             return bestMove != 0;
         }
 
-        public static bool TryGetScore(ulong hash, int depth, int ply, int alpha, int beta, out int score,
-            out ulong move)
+        public static bool TryGetScore(ulong hash, int depth, int ply, int alpha, int beta, 
+            out bool avoidNmp, out int score, out ulong move)
         {
             score = 0;
             move = 0;
+            avoidNmp = false;
 
             if (GetLoadIndex(hash, out int index))
             {
@@ -204,6 +205,14 @@ namespace Pedantic.Chess
 
                 if (item.Depth < depth)
                 {
+                    // even if the TT entry is not good enough to return a score,
+                    // it may be good enough to determine if NMP should be run
+                    if (item.Depth > 0 && item.Flag == TtFlag.UpperBound && 
+                        depth - BasicSearch.NMP[depth] - 1 <= item.Depth &&
+                        item.Score < beta)
+                    {
+                        avoidNmp = true;
+                    }
                     return false;
                 }
 


### PR DESCRIPTION
Score of Pedantic Dev vs Pedantic Base: 986 - 819 - 1173  [0.528] 2978
...      Pedantic Dev playing White: 556 - 380 - 553  [0.559] 1489
...      Pedantic Dev playing Black: 430 - 439 - 620  [0.497] 1489
...      White vs Black: 995 - 810 - 1173  [0.531] 2978
Elo difference: 19.5 +/- 9.7, LOS: 100.0 %, DrawRatio: 39.4 %
SPRT: llr 2.2 (100.2%), lbound -2.2, ubound 2.2 - H1 was accepted