### PR TITLE
Enhanced learning function with --eval_pct and --progress options.

### DIFF
--- a/Pedantic.Tuning/GdTuner.cs
+++ b/Pedantic.Tuning/GdTuner.cs
@@ -56,7 +56,7 @@ namespace Pedantic.Tuning
         }
 
         public override (double Error, double Accuracy, HceWeights Weights, double K) Train(int maxEpoch, TimeSpan? maxTime, 
-            double minError, double precision = TOLERENCE)
+            double minError = 0.0, double precision = TOLERENCE)
         {
             WeightPair[] momentum = new WeightPair[weights.Length];
             WeightPair[] velocity = new WeightPair[weights.Length];

--- a/Pedantic/Properties/launchSettings.json
+++ b/Pedantic/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Pedantic_Learn": {
       "commandName": "Project",
-      "commandLineArgs": "learn --data \"e:/pgn files/training/master_training_data_ver6.0.csv\" --sample 2000000 --iter 600 --reset --maxtime 0:03:00",
+      "commandLineArgs": "learn --data \"e:/pgn files/training/master_training_data_ver6.0.csv\" --sample 2000000 --iter 600 --reset --maxtime 0:03:00 --eval_pct 25 --progress Phase",
       "workingDirectory": "e:\\repos\\Pedantic\\Pedantic\\bin\\Release\\net7.0\\publish",
       "nativeDebugging": false
     },


### PR DESCRIPTION
Allows learning to train using a combination of eval and WDL. --eval_pct specifies an eval percentage and --progress varies this percentage based on the progress of the game using either Ply or Phase.